### PR TITLE
DEV: Move settings descriptions to locales/en.yml

### DIFF
--- a/about.json
+++ b/about.json
@@ -1,6 +1,6 @@
 {
   "about_url": "https://meta.discourse.org/t/categories-tracking-toggle/207150",
-  "license_url": null,
+  "license_url": "https://github.com/discourse/discourse-categories-tracking-toggle/blob/main/LICENSE",
   "assets": {
   },
   "name": "Categories Tracking Toggle",

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,6 +1,11 @@
 en:
   theme_metadata:
     description: "Add a tracking toggle to each category on the categories page"
+    settings:
+      tracking_level: "0: Muted, 1: Normal, 3: Watching first post, 4: Tracking, 5: Watching"
+      tracking_icon: '<a target="_blank" href="https://fontawesome.com/v5.15/icons?d=gallery&m=free">FontAwesome</a> icon name...'
+      mute_level: "0: Muted, 1: Normal, 3: Watching first post, 4: Tracking, 5: Watching"
+      include_subcategories: "When disabled, only the parent category will have its tracking state changed"
   custom_toggle:
     toggle_tracking: "Currently muted, select to track"
     toggle_mute: "Currently tracking, select to mute"

--- a/settings.yml
+++ b/settings.yml
@@ -1,18 +1,14 @@
 tracking_level:
   type: string
   default: 1
-  description: "0: Muted, 1: Normal, 3: Watching first post, 4: Tracking, 5: Watching"
 
 tracking_icon:
   type: string
   default: d-regular
-  description: |
-    <a target="_blank" href="https://fontawesome.com/v5.15/icons?d=gallery&m=free">FontAwesome</a> icon name...
 
 mute_level:
   type: string
   default: 0
-  description: "0: Muted, 1: Normal, 3: Watching first post, 4: Tracking, 5: Watching"
 
 mute_icon:
   type: string
@@ -20,4 +16,3 @@ mute_icon:
 
 include_subcategories:
   default: true
-  description: "When disabled, only the parent category will have its tracking state changed"


### PR DESCRIPTION
This makes translations of the strings possible.
I also added the link to the license file to about.json.